### PR TITLE
Fixed algorithmic bug.

### DIFF
--- a/game2p3s.py
+++ b/game2p3s.py
@@ -144,9 +144,13 @@ class GameArray(np.ndarray):
                     game_array[0, 1:, 1:].argmax(),
                     game_array[0, 1:, 1:].shape
                 )
-        for axis, roll_by in enumerate(subarray_rolls):
-            if roll_by:
-                game_array[:, 1:, 1:] = np.roll(game_array[:, 1:, 1:], -roll_by, axis=axis+1)
+
+        if subarray_rolls[0]:
+            game_array[:, 1:, :] = np.roll(game_array[:, 1:, :],
+                                           1, axis=1)
+        if subarray_rolls[1]:
+            game_array[:, :, 1:] = np.roll(game_array[:, :, 1:],
+                                           1, axis=2)
 
         return game_array.view(self.__class__)
 

--- a/game2p3s.py
+++ b/game2p3s.py
@@ -2,7 +2,7 @@ import numpy as np
 import itertools as it
 import logging
 import copy
-import lukmdo_lehmer.lehmer as lehmer
+import lukmdo_lehmer as lehmer
 
 logger = logging.getLogger('game2p3s')
 

--- a/game2p3s_test.py
+++ b/game2p3s_test.py
@@ -33,6 +33,22 @@ class TestHalfGame(unittest.TestCase):
             half = g.random_half_game().standard
             self.assertEqual(set(half.flatten().tolist()), set(range(1,10)))
 
+    def test_row_and_column_sets_do_not_change(self, how_many=100):
+        def get_row_column_sets(half_game):
+            rows = sorted([sorted(list(half[x])) for x in range(3)])
+            columns = sorted([sorted(list(half[:, x]))
+                           for x in range(3)])
+
+            return tuple(rows), tuple(columns)
+
+        for i in range(how_many):
+            half = g.random_half_game()
+
+            rc_before = get_row_column_sets(half)
+            rc_after = get_row_column_sets(half.standard)
+
+            self.assertEqual(rc_before, rc_after)
+
 
 class TestGame(unittest.TestCase):
     def setUp(self):
@@ -63,7 +79,6 @@ class TestGame(unittest.TestCase):
             self.assertEqual(game[0, 0, 0], 9)
             self.assertEqual(game[0, 1, 1], np.amax(game[0, 1:, 1:]))
 
-
     def test_player_lockstep_during_standardizations(self, how_many=100):
         for i in range(how_many):
             game = g.random_game()
@@ -83,8 +98,6 @@ class TestGame(unittest.TestCase):
 
                 self.assertEqual(p1[x,y], sp1[sx,sy])
 
-
-
     def test_player_strategy_extraction(self, how_many=100):
         for i in range(how_many):
             game = g.random_game().standard
@@ -97,7 +110,28 @@ class TestGame(unittest.TestCase):
             self.assertTrue((p0 == p0_direct).all())
             self.assertTrue((p1 == p1_direct).all())
 
+    def test_row_and_column_sets_do_not_change(self, how_many=100):
+        def get_row_column_sets(full_game):
+            rows = sorted([sorted(full_game[:, x].tolist()) for x in range(3)])
+            columns = sorted([sorted(full_game[:, :, x].tolist())
+                           for x in range(3)])
+
+            return tuple(rows), tuple(columns)
+
+        for i in range(how_many):
+            game = g.random_game()
+
+            rc_before = get_row_column_sets(game)
+            rc_after = get_row_column_sets(game.standard)
+
+            self.assertEqual(rc_before, rc_after)
 
 
 if __name__ == '__main__':
-    unittest.main()
+    half_tests = unittest.TestLoader().loadTestsFromTestCase(TestHalfGame)
+    full_tests = unittest.TestLoader().loadTestsFromTestCase(TestGame)
+
+    test_runner = unittest.TextTestRunner(verbosity=3)
+
+    test_runner.run(half_tests)
+    test_runner.run(full_tests)

--- a/game2p3s_test.py
+++ b/game2p3s_test.py
@@ -56,7 +56,7 @@ class TestGame(unittest.TestCase):
 
     def test_lazy_strategy_standard(self):
         standard_is = self.lazy.standard.view(np.ndarray)
-        should_be = np.array([[9, 7, 8], [3, 5, 4], [6, 2, 1]] * 2).reshape((2,3,3))
+        should_be = np.array([[9, 8, 7], [6, 5, 4], [3, 2, 1]] * 2).reshape((2,3,3))
         self.assertTrue((standard_is == should_be).all())
 
     def test_random_mirror_game_standard(self):
@@ -112,8 +112,12 @@ class TestGame(unittest.TestCase):
 
     def test_row_and_column_sets_do_not_change(self, how_many=100):
         def get_row_column_sets(full_game):
-            rows = sorted([sorted(full_game[:, x].tolist()) for x in range(3)])
-            columns = sorted([sorted(full_game[:, :, x].tolist())
+            rows = sorted([sorted(
+                zip(full_game[0, x].tolist(), full_game[1, x].tolist())
+            ) for x in range(3)])
+            columns = sorted([sorted(
+                zip(full_game[0, :, x].tolist(), full_game[1, :, x])
+            )
                            for x in range(3)])
 
             return tuple(rows), tuple(columns)

--- a/lukmdo_lehmer.py
+++ b/lukmdo_lehmer.py
@@ -1,0 +1,259 @@
+"""
+Obtained from gist: https://gist.github.com/lukmdo/7049748
+by Lukasz Dobrzanski
+used here with permission from the author
+---
+
+Permutations by Lehmer codes (http://en.wikipedia.org/wiki/Lehmer_code)
+
+Given input sequence
+>>> seq = ["A", "B", "C", "D"]
+>>> lehmer_code = [2, 1, 0, 0]
+>>> int_from_code(lehmer_code)
+6
+>>> list(lehmer.iter_perm(['A', 'B', 'C']))
+[['A', 'B', 'C'],
+ ['B', 'A', 'C'],
+ ['C', 'B', 'A'],
+ ['A', 'C', 'B'],
+ ['B', 'C', 'A'],
+ ['C', 'A', 'B']]
+
+Swap is the default method, switch to "pick and drop" by pick=True option.
+>>> perm_from_int(seq, 6)
+['C', 'A', 'B', 'D']
+>>> perm_from_int(seq, 6, pick=True)
+['C', 'B', 'A', 'D']
+>>> int_from_perm(seq, ['C', 'A', 'B', 'D'])
+6
+>>> int_from_perm(seq, ['C', 'B', 'A', 'D'], pick=True)
+6
+
+Swap would:
+- swap 0 and 2 elements ["A", "B", "C", "D"] -> ["C", "B", "A", "D"], then
+- swap 1 and 2 elements ["C", "B", "A", "D"] -> ["C", "A", "B", "D"], then
+- no swap (swap 2 and 2)
+- no swap (swap 3 and 3)
+- return ["C", "A", "B", "D"]
+
+Same Lehmer code by "pick and drop" produces different permutation:
+- pick 2 and drop it [], ["A", "B", "C", "D"] -> ["C"], ["A", "B", "D"], then
+- pick 1 and drop it ["C"], ["A", "B", "D"] -> ["C", "B"], ["A", "D"], then
+- pick 0 and drop it ["C", "B"], ["A", "D"] -> ["C", "B", "A"], ["D"], then
+- pick 0 and drop it ["C", "B", "A"], ["D"] -> ["C", "B", "A", "D"], []
+- return ["C", "B", "A", "D"]
+
+Swap is the default one as it requires less operations and can be implemented
+more efficiently (does not require any drop operations...).
+
+Other implementation could be based on Steinhaus-Johnson-Trotter algorithm:
+- http://en.wikipedia.org/wiki/Steinhaus-Johnson-Trotter_algorithm
+- http://www.ics.uci.edu/~eppstein/PADS/Permutations.py
+"""
+import math
+import copy
+
+__all__ = ['perm_from_int', 'int_from_perm', 'int_from_code', 'code_from_int',
+           'perm_from_code', 'code_from_perm', 'iter_perm']
+
+
+def _perm_from_int_pick(base, num):
+    """
+    :type base: list
+    :type num: int
+    :rtype: list
+    """
+    pass
+
+def _perm_from_code_pick(base, code):
+    """
+    :type base: list
+    :type code: list
+    :rtype: list
+    """
+    pass
+
+def _code_from_perm_pick(base, perm):
+    """
+    :type base: list
+    :type perm: list
+    :rtype: list
+    """
+    pass
+
+def _int_from_perm_pick(base, perm):
+    """
+    :type base: list
+    :type perm: list
+    :rtype: int
+    """
+    pass
+
+def _int_from_code_pick(code):
+    """
+    :type code: list
+    :rtype: int
+    """
+    pass
+
+def iter_perm(base, *rargs, **kwargs):
+    """
+    :type base: list
+    :param rargs: range args [start,] stop[, step]
+    :rtype: generator
+    """
+    pick = kwargs.get('pick', None)
+
+    if not rargs:
+        rargs = [math.factorial(len(base))]
+    for i in range(*rargs):
+        yield perm_from_int(base, i, pick=pick)
+
+def int_from_code(code):
+    """
+    :type code: list
+    :rtype: int
+    """
+    num = 0
+    for i, v in enumerate(reversed(code), 1):
+        num *= i
+        num += v
+
+    return num
+
+def code_from_int(size, num):
+    """
+    :type size: int
+    :type num: int
+    :rtype: list
+    """
+    code = []
+    for i in range(size):
+        num, j = divmod(num, size - i)
+        code.append(j)
+
+    return code
+
+
+def perm_from_code(base, code, pick=None):
+    """
+    :type base: list
+    :type code: list
+    :rtype: list
+    """
+    if pick:
+        return _perm_from_code_pick(base, code)
+
+    perm = copy.deepcopy(base)
+    for i in range(len(base) - 1):
+        j = code[i]
+        perm[i], perm[i+j] = perm[i+j], perm[i]
+
+    return perm
+
+def perm_from_int(base, num, pick=None):
+    """
+    :type base: list
+    :type num: int
+    :rtype: list
+    """
+    code = code_from_int(len(base), num)
+    return perm_from_code(base, code, pick=pick)
+
+def code_from_perm(base, perm, pick=None):
+    """
+    :type base: list
+    :type perm: list
+    :rtype: list
+    """
+    if pick:
+        _code_from_perm_pick(base, perm)
+
+    p = copy.deepcopy(base)
+    n = len(base)
+    pos_map = {v: i for i, v in enumerate(base)}
+
+    w = []
+    for i in range(n):
+        d = pos_map[perm[i]] - i
+        w.append(d)
+
+        if not d:
+            continue
+        t = pos_map[perm[i]]
+        pos_map[p[i]], pos_map[p[t]] = pos_map[p[t]], pos_map[p[i]]
+        p[i], p[t] = p[t], p[i]
+
+    return w
+
+def int_from_perm(base, perm, pick=None):
+    """
+    :type base: list
+    :type perm: list
+    :rtype: int
+    """
+    code = code_from_perm(base, perm, pick=pick)
+    return int_from_code(code)
+
+
+import unittest
+
+L4 = [1,2,3,4]
+
+
+class TestLehmer(unittest.TestCase):
+    def test_perm_from_int(self):
+        self.assertEqual(perm_from_int(L4, 0), [1, 2, 3, 4])
+        self.assertEqual(perm_from_int(L4, 1), [2, 1, 3, 4])
+        self.assertEqual(perm_from_int(L4, 2), [3, 2, 1, 4])
+        self.assertEqual(perm_from_int(L4, 3), [4, 2, 3, 1])
+        self.assertEqual(perm_from_int(L4, 4), [1, 3, 2, 4])
+        self.assertEqual(perm_from_int(L4, 5), [2, 3, 1, 4])
+        self.assertEqual(perm_from_int(L4, 6), [3, 1, 2, 4])
+        self.assertEqual(perm_from_int(L4, 7), [4, 3, 2, 1])
+        self.assertEqual(perm_from_int(L4, 8), [1, 4, 3, 2])
+        self.assertEqual(perm_from_int(L4, 9), [2, 4, 3, 1])
+        self.assertEqual(perm_from_int(L4, 10), [3, 4, 1, 2])
+        self.assertEqual(perm_from_int(L4, 11), [4, 1, 3, 2])
+        self.assertEqual(perm_from_int(L4, 12), [1, 2, 4, 3])
+        self.assertEqual(perm_from_int(L4, 13), [2, 1, 4, 3])
+        self.assertEqual(perm_from_int(L4, 14), [3, 2, 4, 1])
+        self.assertEqual(perm_from_int(L4, 15), [4, 2, 1, 3])
+        self.assertEqual(perm_from_int(L4, 16), [1, 3, 4, 2])
+        self.assertEqual(perm_from_int(L4, 17), [2, 3, 4, 1])
+        self.assertEqual(perm_from_int(L4, 18), [3, 1, 4, 2])
+        self.assertEqual(perm_from_int(L4, 19), [4, 3, 1, 2])
+        self.assertEqual(perm_from_int(L4, 20), [1, 4, 2, 3])
+        self.assertEqual(perm_from_int(L4, 21), [2, 4, 1, 3])
+        self.assertEqual(perm_from_int(L4, 22), [3, 4, 2, 1])
+        self.assertEqual(perm_from_int(L4, 23), [4, 1, 2, 3])
+        self.assertEqual(perm_from_int(L4, 24), perm_from_int(L4, 0))
+
+    def test_int_from_perm(self):
+        self.assertEqual(int_from_perm(L4, [1, 2, 3, 4]), 0)
+        self.assertEqual(int_from_perm(L4, [2, 1, 3, 4]), 1)
+        self.assertEqual(int_from_perm(L4, [3, 2, 1, 4]), 2)
+        self.assertEqual(int_from_perm(L4, [4, 2, 3, 1]), 3)
+        self.assertEqual(int_from_perm(L4, [1, 3, 2, 4]), 4)
+        self.assertEqual(int_from_perm(L4, [2, 3, 1, 4]), 5)
+        self.assertEqual(int_from_perm(L4, [3, 1, 2, 4]), 6)
+        self.assertEqual(int_from_perm(L4, [4, 3, 2, 1]), 7)
+        self.assertEqual(int_from_perm(L4, [1, 4, 3, 2]), 8)
+        self.assertEqual(int_from_perm(L4, [2, 4, 3, 1]), 9)
+        self.assertEqual(int_from_perm(L4, [3, 4, 1, 2]), 10)
+        self.assertEqual(int_from_perm(L4, [4, 1, 3, 2]), 11)
+        self.assertEqual(int_from_perm(L4, [1, 2, 4, 3]), 12)
+        self.assertEqual(int_from_perm(L4, [2, 1, 4, 3]), 13)
+        self.assertEqual(int_from_perm(L4, [3, 2, 4, 1]), 14)
+        self.assertEqual(int_from_perm(L4, [4, 2, 1, 3]), 15)
+        self.assertEqual(int_from_perm(L4, [1, 3, 4, 2]), 16)
+        self.assertEqual(int_from_perm(L4, [2, 3, 4, 1]), 17)
+        self.assertEqual(int_from_perm(L4, [3, 1, 4, 2]), 18)
+        self.assertEqual(int_from_perm(L4, [4, 3, 1, 2]), 19)
+        self.assertEqual(int_from_perm(L4, [1, 4, 2, 3]), 20)
+        self.assertEqual(int_from_perm(L4, [2, 4, 1, 3]), 21)
+        self.assertEqual(int_from_perm(L4, [3, 4, 2, 1]), 22)
+        self.assertEqual(int_from_perm(L4, [4, 1, 2, 3]), 23)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fix for the following bug noted by Austin:

> I think the game.standard() output at 7:02 in your vid shows something
> wrong. The numbers {4,9,6} appear in a row in player 1's part of game.
> But in game.standard() there is no row containing the numbers {4,9,6}
> (in any order). 

> Another way to see it (same example, different inconsistency) is that in
> game, the numbers 9 and 2 do not appear in the same row. But in
> game.standard() they do. However, no sequence of row and column
> switches could cause that to happen.
